### PR TITLE
Include GoLand

### DIFF
--- a/programming/goland/actions.py
+++ b/programming/goland/actions.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+
+from pisi.actionsapi import get, pisitools, shelltools
+import shutil
+
+WorkDir = "."
+Version =  get.srcVERSION()
+
+def install():
+    shutil.rmtree("GoLand-%s/jre64" % Version)
+    pisitools.insinto("/opt/goland", "GoLand-*/*")
+    pisitools.dosym("/opt/goland/bin/goland.sh", "/usr/bin/goland")

--- a/programming/goland/files/goland.desktop
+++ b/programming/goland/files/goland.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Goland
+Icon=/opt/goland/bin/goland.png
+Exec=goland %f
+Comment=The Drive to Develop
+Categories=Development;IDE;
+Terminal=false
+StartupWMClass=jetbrains-goland

--- a/programming/goland/pspec.xml
+++ b/programming/goland/pspec.xml
@@ -1,0 +1,41 @@
+<PISI>
+    <Source>
+        <Name>goland</Name>
+        <Packager>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Packager>
+        <License>GPL-2.0</License>
+        <License>Proprietary</License>
+        <PartOf>programming</PartOf>
+        <Summary xml:lang="en">Goland - an IDE for the Go Language</Summary>
+        <Description xml:lang="en">Goland - an IDE for the Go Language</Description>
+        <Archive sha1sum="ae74cc23bfa4a309432f40698c611dccd2448ca0" type="targz">https://download.jetbrains.com/go/goland-2018.2.4.tar.gz</Archive>
+    </Source>
+    <Package>
+        <Name>goland</Name>
+        <Summary xml:lang="en">Goland - an IDE for the Go Language</Summary>
+        <Description xml:lang="en">Goland - an IDE for the Go Language</Description>
+        <PartOf>programming</PartOf>
+        <Files>
+            <Path fileType="data">/opt/goland</Path>
+            <Path fileType="data">/usr/bin/goland</Path>
+            <Path fileType="data">/usr/share/applications/goland.desktop</Path>
+        </Files>
+        <AdditionalFiles>
+            <AdditionalFile owner="root" permission="0644" target="/usr/share/applications/goland.desktop">goland.desktop</AdditionalFile>
+        </AdditionalFiles>
+        <RuntimeDependencies>
+            <Dependency>openjdk-8</Dependency>
+        </RuntimeDependencies>
+    </Package>
+    <History>
+    <Update release="1">
+            <Date>2018-11-17</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Initial inclusion of GoLand</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
GoLand is the only IDE missing from the JetBrains IDEs.
I have been maintaining a package over at https://github.com/ahahn94/my-3rd-party for almost a year.
I know that this repo does in general not accept new packages, but as this package has always been maintained by me alongside the other IDEs I would like to ask you to include it anyways.

So. for the sake of completeness, please accept this PR.

Signed-off-by: ahahn94 <ahahn94@outlook.com>