### PR TITLE
Update gitkraken to 4.2.1

### DIFF
--- a/programming/gitkraken/pspec.xml
+++ b/programming/gitkraken/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>The downright luxurious Git client, for Windows, Mac and Linux</Summary>
         <Description>The downright luxurious Git client, for Windows, Mac and Linux</Description>
         <License>EULA</License>
-        <Archive sha1sum="71b5609bb11c7fa512f5f81c85c48e190c4b08cb" type="binary">https://release.gitkraken.com/linux/gitkraken-amd64.deb</Archive>
+        <Archive sha1sum="50d858ec7164e3c7a4a434d58c97108d4a4ce9a6" type="binary">https://release.gitkraken.com/linux/gitkraken-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>libxscrnsaver</Dependency>
             <Dependency>gconf</Dependency>
@@ -35,6 +35,14 @@
     </Package>
 
     <History>
+        <Update release="66">
+            <Date>01-23-2019</Date>
+            <Version>4.2.1</Version>
+            <Comment>Update to 4.2.1</Comment>
+            <Name>Pierre-Yves</Name>
+            <Email>pyu@riseup.net</Email>
+        </Update>
+
         <Update release="65">
             <Date>01-03-2019</Date>
             <Version>4.2.0</Version>


### PR DESCRIPTION
Release notes available [here](https://support.gitkraken.com/release-notes/current/#version-421)

Signed-off-by: Pierre-Yves <pyu@riseup.net>