### PR TITLE
Update README to remove outdated info about Ubuntu Rally

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@ Third Party Apps (DEPRECATED)
 =============================
 
 **Note**: This repo will not accept NEW packages as we are replacing the
-majority of them in Solus with Snaps. After the Ubuntu Rally (NYC) at the
-end of September 2017, we'll have Snaps integrated in the Software Center,
-and will begin forceful deprecation of this repository.
+majority of them in Solus with Snaps. After we have Snaps integrated in the Software Center
+we will begin forceful deprecation of this repository.
 
 This repo contains the build files required to create packages that cannot
 be redistributed, whether for licensing restrictions or otherwise.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 Third Party Apps (DEPRECATED)
 =============================
 
-**Note**: This repo will not accept NEW packages as we are replacing the
-majority of them in Solus with Snaps. After we have Snaps integrated in the Software Center
-we will begin forceful deprecation of this repository.
+**Note**: This repo will not accept NEW packages as we are replacing the majority of them in Solus with Snaps. After we have Snaps integrated in the Software Center we will begin forceful deprecation of this repository.
 
-This repo contains the build files required to create packages that cannot
-be redistributed, whether for licensing restrictions or otherwise.
+This repo contains the build files required to create packages that cannot be redistributed, whether for licensing restrictions or otherwise.
 
 For more information about 3rd party applications in Solus, visit our Help Center page at https://getsol.us/articles/software/third-party/en/.
 
 
-DO NOT PUSH BINARY PACKAGES. The git history has been reset because it ballooned
-to nearly 300MB in size. :)
+DO NOT PUSH BINARY PACKAGES. The git history has been reset because it ballooned to nearly 300MB in size. :)


### PR DESCRIPTION
Doesn't seem necessary, and increasingly unreasonable, to still have this in the description.