### PR TITLE
Add Synology Drive Client version 1.1.4-10580

### DIFF
--- a/network/download/synology-drive-client/actions.py
+++ b/network/download/synology-drive-client/actions.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import get, pisitools, shelltools
+
+
+NoStrip = ["/"]
+IgnoreAutodep = True
+
+def setup():
+    shelltools.system("ar xf synology-drive-10580.x86_64.deb")
+    shelltools.system("tar xf data.tar.xz")
+
+def install():
+    pisitools.insinto("/", "usr")
+    pisitools.insinto("/", "opt")

--- a/network/download/synology-drive-client/pspec.xml
+++ b/network/download/synology-drive-client/pspec.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://getsol.us/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>synology-drive-client</Name>
+        <Packager>
+            <Name>Sebastian Brandt</Name>
+            <Email>seb-br@mailbox.org</Email>
+        </Packager>
+        <Summary>Synology Drive Client</Summary>
+        <Description>Synology Drive Client is an application which sync files between your computers and Synology NAS via the Internet, so that your data and documents are always up-to-date and stay beside you.</Description>
+        <License>Custom - https://www.synology.com/en-global/company/legal/terms_conditions</License>
+		<Archive sha1sum="5cde25ec1820c48adb8d3ed5bfec4805b77f7169" type="binary">https://global.download.synology.com/download/Tools/SynologyDriveClient/1.1.4-10580/Ubuntu/Installer/x86_64/synology-drive-10580.x86_64.deb</Archive>
+        <BuildDependencies>
+                <Dependency>binutils</Dependency>
+        </BuildDependencies>   
+    </Source>
+
+    <Package>
+        <Name>synology-drive-client</Name>
+        <Files>
+            <Path fileType="*">/</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>06-17-2019</Date>
+            <Version>1.1.4.10580</Version>
+            <Comment>Initial inclusion.</Comment>
+            <Name>Sebastian Brandt</Name>
+            <Email>seb-br@mailbox.org</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
I'm aware that the Solus 3rd-party repo is deprecated. Please consider this PR though: Synology Drive Client  integrates with Nautilus for icon overlays and runs in the background. It might not be a good candidate for a snap.
Synology Drive Client is a new cloud client for Synology NAS that behaves more like traditional cloud clients. It is new software independent of the previous Synology Cloud Station Drive.
I've tested the client on current Solus Budgie and file sync'ing as well as Nautilus overlays work. Minor issue is that its icon is not shown in Budgie system tray - it is there though, just without a visible icon.