### PR TITLE
Add gtk2-engine-murrine runtime dependency for Spotify

### DIFF
--- a/multimedia/music/spotify/pspec.xml
+++ b/multimedia/music/spotify/pspec.xml
@@ -29,11 +29,20 @@
         <RuntimeDependencies>
             <Dependency>curl-gnutls</Dependency>
             <Dependency>gconf</Dependency>
+            <Dependency>gtk2-engine-murrine</Dependency>
         </RuntimeDependencies>
 
     </Package>
 
     <History>
+        <Update release="54">
+            <Date>02-07-2020</Date>
+            <Version>1.1.10.546</Version>
+            <Comment>Add gtk2-engine-murrine runtime dependency</Comment>
+            <Name>Alexander Koskovich</Name>
+            <Email>zvnexus@outlook.com</Email>
+        </Update>
+
         <Update release="53">
             <Date>01-25-2020</Date>
             <Version>1.1.10.546</Version>


### PR DESCRIPTION
(spotify:123163): Gtk-WARNING **: 23:24:23.756: Unable to locate theme engine in module_path: "murrine",