### PR TITLE
Synology drive client

### DIFF
--- a/network/download/synology-drive-client/actions.py
+++ b/network/download/synology-drive-client/actions.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import get, pisitools, shelltools
+
+
+NoStrip = ["/"]
+IgnoreAutodep = True
+
+def setup():
+    shelltools.system("ar xf synology-drive-client-11112.x86_64.deb")
+    shelltools.system("tar xf data.tar.xz")
+
+def install():
+    pisitools.insinto("/", "usr")
+    pisitools.insinto("/", "opt")

--- a/network/download/synology-drive-client/pspec.xml
+++ b/network/download/synology-drive-client/pspec.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://getsol.us/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>synology-drive-client</Name>
+        <Packager>
+            <Name>Thomas Faddegon</Name>
+            <Email>thomas@wapnet.nl</Email>
+        </Packager>
+        <Summary>Cloud Drive Client</Summary>
+        <Description>Cloud Drive Client is an application which sync files between your computers and Synology NAS via the Internet, so that your data and documents are always up-to-date and stay beside you.</Description>
+        <License>Custom - https://www.synology.com/en-global/company/legal/terms_conditions</License>
+        <Archive sha1sum="b7a45d8e06fdec15a08ee54eb0b95885d430aa1f" type="binary">https://global.download.synology.com/download/Utility/SynologyDriveClient/2.0.4-11112/Ubuntu/Installer/x86_64/synology-drive-client-11112.x86_64.deb</Archive>
+        <BuildDependencies>
+                <Dependency>binutils</Dependency>
+        </BuildDependencies>   
+    </Source>
+
+    <Package>
+        <Name>synology-drive-client</Name>
+        <Files>
+            <Path fileType="*">/</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>05-03-2021</Date>
+            <Version>2.0.4-11112</Version>
+            <Comment>Update to 2.0.4-11112</Comment>
+            <Name>Thomas Faddegon</Name>
+            <Email>thomas@wapnet.nl</Email>
+        </Update>
+    </History>
+</PISI>

--- a/network/download/synology-drive-client/pspec.xml
+++ b/network/download/synology-drive-client/pspec.xml
@@ -26,7 +26,7 @@
     <History>
         <Update release="1">
             <Date>05-03-2021</Date>
-            <Version>2.0.4-11112</Version>
+            <Version>2.0.4.11112</Version>
             <Comment>Update to 2.0.4-11112</Comment>
             <Name>Thomas Faddegon</Name>
             <Email>thomas@wapnet.nl</Email>


### PR DESCRIPTION
Hi,
I create a working installer for the synology drive client. Synology drive client is the successor of cloud station drive.

You can test it for yourself:
sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/L0g0ff/3rd-party/master/network/download/synology-drive-client/pspec.xml
sudo eopkg it synology-drive-client*.eopkg;sudo rm synology-drive-client*.eopkg

I hope you can add this change to the official branch. This is the first time I create a debian to solus port. If I did something wrong please sent me what to do and I will fix it.

Kind regards,
Thomas
