### PR TITLE
Python3 port

### DIFF
--- a/desktop/font/mscorefonts/actions.py
+++ b/desktop/font/mscorefonts/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/multimedia/music/bitwig-studio/actions.py
+++ b/multimedia/music/bitwig-studio/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/multimedia/music/ocenaudio/actions.py
+++ b/multimedia/music/ocenaudio/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/multimedia/music/spotify/actions.py
+++ b/multimedia/music/spotify/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/multimedia/music/sunvox/actions.py
+++ b/multimedia/music/sunvox/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/multimedia/video/plexmediaserver/actions.py
+++ b/multimedia/video/plexmediaserver/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/download/insync/actions.py
+++ b/network/download/insync/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/download/spideroak/actions.py
+++ b/network/download/spideroak/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/download/synology-cloud-station-drive/actions.py
+++ b/network/download/synology-cloud-station-drive/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/im/franz/actions.py
+++ b/network/im/franz/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created for Solus Operating System
 

--- a/network/im/slack-desktop/actions.py
+++ b/network/im/slack-desktop/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/im/viber/actions.py
+++ b/network/im/viber/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/util/anydesk/actions.py
+++ b/network/util/anydesk/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/util/teamviewer/actions.py
+++ b/network/util/teamviewer/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 
@@ -27,5 +27,5 @@ def install():
 
     pisitools.dodir("/etc/teamviewer")
 
-    shelltools.chmod("%s/opt/teamviewer/doc/*" % get.installDIR(),0755)
-    shelltools.chmod("%s/opt/teamviewer/tv_bin/*" % get.installDIR(),0755)
+    shelltools.chmod("%s/opt/teamviewer/doc/*" % get.installDIR(),0o0755)
+    shelltools.chmod("%s/opt/teamviewer/tv_bin/*" % get.installDIR(),0o0755)

--- a/network/web/browser/google-chrome-beta/actions.py
+++ b/network/web/browser/google-chrome-beta/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/web/browser/google-chrome-stable/actions.py
+++ b/network/web/browser/google-chrome-stable/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/web/browser/google-chrome-unstable/actions.py
+++ b/network/web/browser/google-chrome-unstable/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/network/web/google-earth/actions.py
+++ b/network/web/google-earth/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/office/mendeleydesktop/actions.py
+++ b/office/mendeleydesktop/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/office/moneydance/actions.py
+++ b/office/moneydance/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/office/pomodoneapp/actions.py
+++ b/office/pomodoneapp/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/office/scrivener/actions.py
+++ b/office/scrivener/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 
@@ -13,6 +13,7 @@ def setup():
     shelltools.system("pwd")
     shelltools.system("ar xf scrivener-%s-amd64.deb" % Version)
     shelltools.system("tar xf data.tar.gz")
+    shelltools.system("asciify usr")
     shelltools.system("mkdir usr/share/icons/hicolor")
     pisitools.move("usr/share/icons/*x*", "usr/share/icons/hicolor/")
     shelltools.system("rm usr/share/scrivener/bin/scrivener.sh")

--- a/office/scrivener/pspec.xml
+++ b/office/scrivener/pspec.xml
@@ -14,6 +14,7 @@
         <Archive sha1sum="e3d214b8510a54d5363679a9ea31fee303435f63" type="binary">https://www.literatureandlatte.com/scrivenerforlinux/scrivener-1.9.0.1-amd64.deb</Archive>
 
         <BuildDependencies>
+            <Dependency>asciify</Dependency>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
     </Source>

--- a/programming/android-studio/actions.py
+++ b/programming/android-studio/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools
 

--- a/programming/clion/actions.py
+++ b/programming/clion/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/datagrip/actions.py
+++ b/programming/datagrip/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/gitkraken/actions.py
+++ b/programming/gitkraken/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/programming/goland/actions.py
+++ b/programming/goland/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/idea/actions.py
+++ b/programming/idea/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/pycharm-ce/actions.py
+++ b/programming/pycharm-ce/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/pycharm/actions.py
+++ b/programming/pycharm/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/rider/actions.py
+++ b/programming/rider/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/rubymine/actions.py
+++ b/programming/rubymine/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/programming/sublime-text/actions.py
+++ b/programming/sublime-text/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 

--- a/programming/unity-editor/actions.py
+++ b/programming/unity-editor/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import pisitools, shelltools
 

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from pisi.actionsapi import get, pisitools, shelltools
 import shutil

--- a/security/enpass/actions.py
+++ b/security/enpass/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Created For Solus Operating System
 


### PR DESCRIPTION
To be merged once Python3 eopkg is the default (if 3rd-party isn't completely removed until then)

repo-wide: switch `action.py` to explicit `/usr/bin/env python3` shebangs

scrivener: Use asciify to fix encoding errors

teamviewer: fix octal format for chmod command