### PR TITLE
Updates of the JetBrains IDEs for week 37/2024

### DIFF
--- a/programming/goland/pspec.xml
+++ b/programming/goland/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Goland - an IDE for the Go Language</Summary>
         <Description xml:lang="en">Goland - an IDE for the Go Language</Description>
-        <Archive sha1sum="a2f7e4125882877008041ecf4bd4a6e1d7124dd2" type="targz">https://download.jetbrains.com/go/goland-2024.2.1.tar.gz</Archive>
+        <Archive sha1sum="063b9280d722967d4140c11bc2c80a43b735bbf5" type="targz">https://download.jetbrains.com/go/goland-2024.2.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>goland</Name>
@@ -30,7 +30,14 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="91">
+    <Update release="92">
+            <Date>2024-09-14</Date>
+            <Version>2024.2.1.1</Version>
+            <Comment>Updated to 2024.2.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
+        <Update release="91">
             <Date>2024-08-31</Date>
             <Version>2024.2.1</Version>
             <Comment>Updated to 2024.2.1</Comment>

--- a/programming/rider/pspec.xml
+++ b/programming/rider/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Summary>
         <Description xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Description>
-        <Archive sha1sum="3828ea7f28a99778c903fd4ef8f3a78124603398" type="targz">https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.3.tar.gz</Archive>
+        <Archive sha1sum="4bfbd124e09b7aafd47425943839e1905b49718d" type="targz">https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rider</Name>
@@ -30,7 +30,14 @@
         </RuntimeDependencies>
     </Package>
     <History>
-      <Update release="86">
+      <Update release="87">
+            <Date>2024-09-14</Date>
+            <Version>2024.2.4</Version>
+            <Comment>Updated to 2024.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
+        <Update release="86">
             <Date>2024-08-31</Date>
             <Version>2024.2.3</Version>
             <Comment>Updated to 2024.2.3</Comment>


### PR DESCRIPTION
As there are some problems with `eopkg` at the moment, I can't build and test the new packages of the JetBrains IDEs.

I have updated the `pspec.xml` files with the new definitions, but they have to be build and tested with a working copy of eopkg, which I don't have at the moment.

See #78 for related problems.